### PR TITLE
Switch citations

### DIFF
--- a/02-data_uses.Rmd
+++ b/02-data_uses.Rmd
@@ -70,7 +70,7 @@ Data used for risk prediction can come from various sources, including:
   * Clinical Data: This includes patient demographics, medical history, laboratory results, and imaging studies.
   * Genetic Data: Genetic information, such as DNA sequencing results, can provide valuable insights into an individual's susceptibility to certain diseases.
   * Environmental and Lifestyle Data: Factors such as diet, exercise habits, smoking status, and environmental exposures can influence disease risk and may be included in risk prediction models.
-  * Biomarkers: Biological markers indicative of disease or physiological processes can be used as predictors in risk models [@Bodaghi_Fattahi_Ramazani_2023].
+  * Biomarkers: Biological markers indicative of disease or physiological processes can be used as predictors in risk models [@deGramont_etal_2015].
 
 Once relevant data is collected, statistical and machine learning techniques can be applied to develop predictive models. These models aim to identify patterns and relationships within the data that are associated with the outcome of interest. Common techniques include logistic regression, decision trees, random forests, support vector machines, and neural networks.
 

--- a/02-data_uses.Rmd
+++ b/02-data_uses.Rmd
@@ -70,7 +70,7 @@ Data used for risk prediction can come from various sources, including:
   * Clinical Data: This includes patient demographics, medical history, laboratory results, and imaging studies.
   * Genetic Data: Genetic information, such as DNA sequencing results, can provide valuable insights into an individual's susceptibility to certain diseases.
   * Environmental and Lifestyle Data: Factors such as diet, exercise habits, smoking status, and environmental exposures can influence disease risk and may be included in risk prediction models.
-  * Biomarkers: Biological markers indicative of disease or physiological processes can be used as predictors in risk models [@deGramont_etal_2015, @Taylor_Ankerst_Andridge_2008].
+  * Biomarkers: Biological markers indicative of disease or physiological processes can be used as predictors in risk models [@deGramont_etal_2015; @Taylor_Ankerst_Andridge_2008].
 
 Once relevant data is collected, statistical and machine learning techniques can be applied to develop predictive models. These models aim to identify patterns and relationships within the data that are associated with the outcome of interest. Common techniques include logistic regression, decision trees, random forests, support vector machines, and neural networks.
 

--- a/02-data_uses.Rmd
+++ b/02-data_uses.Rmd
@@ -70,7 +70,7 @@ Data used for risk prediction can come from various sources, including:
   * Clinical Data: This includes patient demographics, medical history, laboratory results, and imaging studies.
   * Genetic Data: Genetic information, such as DNA sequencing results, can provide valuable insights into an individual's susceptibility to certain diseases.
   * Environmental and Lifestyle Data: Factors such as diet, exercise habits, smoking status, and environmental exposures can influence disease risk and may be included in risk prediction models.
-  * Biomarkers: Biological markers indicative of disease or physiological processes can be used as predictors in risk models [@deGramont_etal_2015].
+  * Biomarkers: Biological markers indicative of disease or physiological processes can be used as predictors in risk models [@deGramont_etal_2015, @Taylor_Ankerst_Andridge_2008].
 
 Once relevant data is collected, statistical and machine learning techniques can be applied to develop predictive models. These models aim to identify patterns and relationships within the data that are associated with the outcome of interest. Common techniques include logistic regression, decision trees, random forests, support vector machines, and neural networks.
 

--- a/book.bib
+++ b/book.bib
@@ -76,6 +76,22 @@
 	language={en} 
 }
 
+@article{Taylor_Ankerst_Andridge_2008, 
+	title={Validation of Biomarker-based risk prediction models}, 
+	volume={14}, 
+	ISSN={1078-0432}, 
+	url={https://pmc.ncbi.nlm.nih.gov/articles/PMC3896456/}, 
+	DOI={10.1158/1078-0432.CCR-07-4534}, 
+	abstractNote={The increasing availability and use of predictive models to facilitate informed decision making highlights the need for careful assessment of the validity of these models. In particular, models involving biomarkers require careful validation for two reasons: issues with overfitting when complex models involve a large number of biomarkers, and inter-laboratory variation in assays used to measure biomarkers. In this paper we distinguish between internal and external statistical validation. Internal validation, involving training-testing splits of the available data or cross-validation, is a necessary component of the model building process and can provide valid assessments of model performance. External validation consists of assessing model performance on one or more datasets collected by different investigators from different institutions. External validation is a more rigorous procedure necessary for evaluating whether the predictive model will generalize to populations other than the one on which it was developed. We stress the need for an external dataset to be truly external, that is, to play no role in model development and ideally be completely unavailable to the researchers building the model. In addition to reviewing different types of validation, we describe different types and features of predictive models and strategies for model building, as well as measures appropriate for assessing their performance in the context of validation. No single measure can characterize the different components of the prediction, and the use of multiple summary measures is recommended.}, 
+	number={19}, 
+	journal={Clinical cancer research : an official journal of the American Association for Cancer Research}, 
+	author={Taylor, Jeremy M. G. and Ankerst, Donna P. and Andridge, Rebecca R.}, 
+	year={2008}, 
+	month=oct, 
+	pages={5977–5983} 
+}
+
+
 @article{BoydCCT2023,
   title={Equity and bias in electronic health records data},
   volume={130},

--- a/book.bib
+++ b/book.bib
@@ -58,19 +58,22 @@
   url={https://qualityindicators.ahrq.gov/measures/qi_resources} 
 }
 
-@article{Bodaghi_Fattahi_Ramazani_2023,
- title={Biomarkers: Promising and valuable tools towards diagnosis, prognosis and treatment of Covid-19 and other diseases},
- volume={9},
- ISSN={2405-8440},
- url={https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9884646/},
- DOI={10.1016/j.heliyon.2023.e13323},
- abstractNote={The use of biomarkers as early warning systems in the evaluation of disease risk has increased markedly in the last decade. Biomarkers are indicators of typical biological processes, pathogenic processes, or pharmacological reactions to therapy. The application and identification of biomarkers in the medical and clinical fields have an enormous impact on society. In this review, we discuss the history, various definitions, classifications, characteristics, and discovery of biomarkers. Furthermore, the potential application of biomarkers in the diagnosis, prognosis, and treatment of various diseases over the last decade are reviewed. The present review aims to inspire readers to explore new avenues in biomarker research and development.},
- number={2},
- journal={Heliyon},
- author={Bodaghi, Ali and Fattahi, Nadia and Ramazani, Ali},
- year={2023},
- month=jan,
- pages={e13323}
+@article{deGramont_etal_2015, 
+	title={Pragmatic issues in biomarker evaluation for targeted therapies in cancer}, 
+	volume={12}, 
+	rights={2014 Springer Nature Limited}, 
+	ISSN={1759-4782}, 
+	url={https://www.nature.com/articles/nrclinonc.2014.202}, 
+	DOI={10.1038/nrclinonc.2014.202}, 
+	abstractNote={Predictive biomarkers are essential tools with regard to personalized medicine and health economics, and are crucial to improve the success rate of new therapiesImplementation of biomarkers into clinical practice presents biological, clinical and logistical challenges, in particular, relating to standardization across multiple countries and clinical practicesDuring biomarker development, robust laboratory methodology is necessary at all analytical phases, from pre-analytical (sample definition, handling and processing) to analytical (data and quality-control recording) and post-analytical (data reporting and interpretation)A series of recommendations can be made to increase biomarker reliability and facilitate development of predictive biomarkers that can ultimately be used to provide benefit for patients with cancer}, 
+	number={4}, 
+	journal={Nature Reviews Clinical Oncology}, 
+	publisher={Nature Publishing Group}, 
+	author={de Gramont, Armand and Watson, Sarah and Ellis, Lee M. and Rodón, Jordi and Tabernero, Josep and de Gramont, Aimery and Hamilton, Stanley R.}, 
+	year={2015}, 
+	month=apr, 
+	pages={197–212}, 
+	language={en} 
 }
 
 @article{BoydCCT2023,


### PR DESCRIPTION
Received a retraction notice for one of the citations I was using for biomarkers: https://www-sciencedirect-com.fhcrc.idm.oclc.org/science/article/pii/S2405844023005303  

so I've replaced it with two articles discussing biomarkers and their use in risk models. Both focus on considerations for careful use
* https://doi.org/10.1158/1078-0432.CCR-07-4534
* https://doi.org/10.1038/nrclinonc.2014.202

I'm not sure how this change will impact development on other branches, so asking both of you to review for visibility.

Also noting there's a few sentences I started in this section about risk models that I hadn't filled in yet. 